### PR TITLE
update docker image and volume mount path for xenial branch

### DIFF
--- a/test-tools/start-image.sh
+++ b/test-tools/start-image.sh
@@ -11,7 +11,7 @@ docker run --rm -t -i \
 	-e HUGO_VERSION \
 	-e PHP_VERSION \
 	-e GO_VERSION \
-	-v ${REPO_PATH}:/opt/repo \
+	-v ${REPO_PATH}:/opt/buildhome/repo \
 	-v ${BASE_PATH}/run-build.sh:/usr/local/bin/build \
 	-v ${BASE_PATH}/run-build-functions.sh:/usr/local/bin/run-build-functions.sh \
-	netlify/build /bin/bash
+	netlify/build:xenial /bin/bash


### PR DESCRIPTION
When I tried to test run docker build image, it failed with error message `package.json` not found. Upon further inspection in script found that script was mounting to different folder. After adjusting this volume mount path package.json was found properly.

By default test command tried to create image from latest build, whereas the command sample provided is for `xenial` docker image. So updated docker image path to make it consistent with sample command `docker pull netlify/build:xenial`

Changelogs:

- update repo volume mount to /opt/buildhome/repo
- set docker image to xenial in xenial branch.